### PR TITLE
Cleanup async code

### DIFF
--- a/nina_xmpp/__init__.py
+++ b/nina_xmpp/__init__.py
@@ -48,23 +48,9 @@ class NinaXMPP:
                 None,
                 self.message_received,
             )
+
             update_feeds_task = asyncio.create_task(self.update_feeds_task())
-            await self.make_sigint_event().wait()
-            update_feeds_task.cancel()
-
-        try:
-            await update_feeds_task
-        except asyncio.CancelledError:
-            pass
-
-    def make_sigint_event(self):
-        event = asyncio.Event()
-        loop = asyncio.get_event_loop()
-        loop.add_signal_handler(
-            signal.SIGINT,
-            event.set,
-        )
-        return event
+            await asyncio.wait({update_feeds_task})
 
     def message_received(self, msg):
         if not msg.body:

--- a/nina_xmpp/__main__.py
+++ b/nina_xmpp/__main__.py
@@ -18,11 +18,7 @@ def main():
 
     main = NinaXMPP(config)
 
-    loop = asyncio.get_event_loop()
-    try:
-        loop.run_until_complete(main.run())
-    finally:
-        loop.close()
+    asyncio.run(main.run())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- fully switches to the recommended high-level API by not interfering with the loop in any way
- removes the need to manually cleanup tasks by having to wait for a signal
- fixes the problem with the update feeds task where exceptions where only shown on shutdown

This is the first part of the fix for #10