### PR TITLE
Catch HTTP errors

### DIFF
--- a/nina_xmpp/__init__.py
+++ b/nina_xmpp/__init__.py
@@ -120,7 +120,12 @@ class NinaXMPP:
                         headers['If-Modified-Since'] = feed.last_modified
                     if feed.etag:
                         headers['If-None-Match'] = feed.etag
-                response = await http_client.get(url, headers=headers)
+
+                try:
+                    response = await http_client.get(url, headers=headers)
+                except httpx.RequestError:
+                    self.logger.exception(f'Could not update feed {url}')
+                    continue
 
                 if response.status_code == httpx.codes.OK:
                     feed.last_modified = response.headers.get('Last-Modified')


### PR DESCRIPTION
This logs all request errors via httpx that can happen from time to time (connect error, timeout, ..) and continues updating other feeds instead of terminating the task.
See also https://www.python-httpx.org/exceptions/

This should greatly improve stability of the update feeds task which is related to #10