### PR TITLE
Increase HTTP timeout from implicit 5 to explicit 10 seconds

### DIFF
--- a/nina_xmpp/__init__.py
+++ b/nina_xmpp/__init__.py
@@ -104,7 +104,7 @@ class NinaXMPP:
             await asyncio.sleep(self.config['check_interval'])
 
     async def update_feeds(self):
-        async with httpx.AsyncClient(trust_env=False) as http_client:
+        async with httpx.AsyncClient(trust_env=False, timeout=10.0) as http_client:
             for url in self.config['feeds']:
                 headers = {}
                 try:


### PR DESCRIPTION
I noticed in #13 that the feeds are updating stable now for ~24 hours but from time to time (but then a few times in a row) there are connect timeouts. Could be that there is some throttling going on or the API or my raspberry pi are just slow sometimes.
Anyways, waiting a bit longer does make sense then IMO.

See also https://www.python-httpx.org/advanced/#timeout-configuration