### PR TITLE
Expose severity

### DIFF
--- a/nina_xmpp/__init__.py
+++ b/nina_xmpp/__init__.py
@@ -179,13 +179,18 @@ class NinaXMPP:
                 'instruction',
             )
         ]
-        for info in ('effective', 'expires'):
+        for info in ('severity', 'effective', 'expires'):
             if info not in event['info'][0]:
                 continue
 
+            if info in ('effective', 'expires'):
+                info_value = reformat_date(event['info'][0][info])
+            else:
+                info_value = _(event['info'][0][info])
+
             lines += ['%s: %s' % (
                 _(info.capitalize()),
-                reformat_date(event['info'][0][info]),
+                info_value,
             )]
 
         msg = aioxmpp.Message(

--- a/nina_xmpp/locale/de/LC_MESSAGES/nina_xmpp.po
+++ b/nina_xmpp/locale/de/LC_MESSAGES/nina_xmpp.po
@@ -72,6 +72,18 @@ msgstr "{url} (zuletzt aktualisiert: {last_modified})"
 msgid "The feeds are checked for updates every {} seconds"
 msgstr "Die Warnquellen werden alle {} Sekunden auf Updates geprüft"
 
+msgid "Severity"
+msgstr "Schweregrad"
+
+msgid "Minor"
+msgstr "Leicht"
+
+msgid "Moderate"
+msgstr "Mittel"
+
+msgid "Severe"
+msgstr "Schwer"
+
 #: nina_xmpp/__init__.py:190
 msgid "Effective"
 msgstr "Gilt ab"

--- a/nina_xmpp/locale/nina_xmpp.pot
+++ b/nina_xmpp/locale/nina_xmpp.pot
@@ -69,6 +69,18 @@ msgstr ""
 msgid "The feeds are checked for updates every {} seconds"
 msgstr ""
 
+msgid "Severity"
+msgstr ""
+
+msgid "Minor"
+msgstr ""
+
+msgid "Moderate"
+msgstr ""
+
+msgid "Severe"
+msgstr ""
+
 #: nina_xmpp/__init__.py:190
 msgid "Effective"
 msgstr ""


### PR DESCRIPTION
An idea that I had today after multiple moderate and then a severe weather warning came up - would be nice to show the severity somehow.

This adds the possibility to directly expose some values and translates them additionally to the date exposures.

Severe messages could be highlighted even more, e.g. severity or whole message in bold or so. In red would be great but I guess XMPP or clients do not support that.. 

Example
![image](https://user-images.githubusercontent.com/5738896/138227685-e7f522f9-f1f0-4058-a7fc-ce6be1d1b380.png)
